### PR TITLE
feat(clubes): implementar permisos de administrador para gestión de c…

### DIFF
--- a/src/routes/club.routes.js
+++ b/src/routes/club.routes.js
@@ -1,12 +1,16 @@
 const express = require("express");
 const router = express.Router();
 const clubCtrl = require("../controllers/club.controller");
+const { authenticate, authorize } = require('../middleware/auth.middleware');
 
+// Rutas públicas - cualquiera puede ver los clubes
 router.get("/filter", clubCtrl.getClubFiltro);
 router.get("/", clubCtrl.getClubs);
-router.post("/", clubCtrl.createClub);
 router.get("/:id", clubCtrl.getClub);
-router.put("/:id", clubCtrl.editClub);
-router.delete("/:id", clubCtrl.deleteClub);
+
+// Rutas protegidas - solo administradores
+router.post("/", authenticate, authorize('admin'), clubCtrl.createClub);
+router.put("/:id", authenticate, authorize('admin'), clubCtrl.editClub);
+router.delete("/:id", authenticate, authorize('admin'), clubCtrl.deleteClub);
 
 module.exports = router;


### PR DESCRIPTION
…lubes

Este commit implementa:
- Protección de rutas para que solo los administradores puedan crear, actualizar y eliminar clubes
- Validaciones exhaustivas para datos de clubes:
  - Verificación de campos obligatorios (nombre, dirección, email, CUIT, fecha/estado afiliación)
  - Validación de formato para email y CUIT
  - Prevención de duplicados (nombre, email, CUIT)
- Bloqueo de eliminación de clubes con personas o equipos asociados
- Funciones auxiliares para validación de datos
- Mantenimiento de rutas públicas para consulta de clubes (GET)
- Ordenamiento alfabético de resultados de clubes

Las validaciones garantizan la integridad de los datos mientras que los controles de acceso aseguran que solo los administradores autenticados puedan realizar operaciones de escritura sobre los clubes.