### PR TITLE
feat(equipos): implementar protección de rutas y validaciones para ge…

### DIFF
--- a/src/controllers/equipo.controller.js
+++ b/src/controllers/equipo.controller.js
@@ -24,7 +24,8 @@ equipoCtrl.getEquipos = async (req, res) => {
                     as: 'categoria', 
                     attributes: ['idCategoria', 'nombre', 'edadMinima', 'edadMaxima']
                 }
-            ]
+            ],
+            order: [['nombre', 'ASC']] // Ordenar alfabéticamente por nombre
         });
         res.status(200).json(equipos);
     } catch (error) {
@@ -41,7 +42,8 @@ equipoCtrl.createEquipo = async (req, res) => {
     /*
     #swagger.tags = ['Equipos']
     #swagger.summary = 'Crear un nuevo Equipo'
-    #swagger.description = 'Agrega un nuevo equipo a la base de datos. Requiere idClub y idCategoria.'
+    #swagger.description = 'Agrega un nuevo equipo a la base de datos. Solo accesible para administradores.'
+    #swagger.security = [{ "bearerAuth": [] }]
     #swagger.parameters['body'] = {
         in: 'body',
         description: 'Datos del equipo a crear.',
@@ -50,35 +52,77 @@ equipoCtrl.createEquipo = async (req, res) => {
     }
     */
     try {
-        const { idClub, idCategoria, ...equipoData } = req.body;
+        // Validaciones de datos
+        const { nombre, idClub, idCategoria, nombreDelegado } = req.body;
+        
+        // Validar campos obligatorios
+        if (!nombre || nombre.trim() === '') {
+            return res.status(400).json({
+                status: "0",
+                msg: "El nombre del equipo es obligatorio"
+            });
+        }
+        
+        if (!idClub) {
+            return res.status(400).json({
+                status: "0",
+                msg: "El club asociado es obligatorio"
+            });
+        }
 
-        // Validar que el Club y la Categoría existan
+        if (!idCategoria) {
+            return res.status(400).json({
+                status: "0",
+                msg: "La categoría asociada es obligatoria"
+            });
+        }
+
+        // Validar que el Club exista
         const clubExistente = await Club.findByPk(idClub);
         if (!clubExistente) {
             return res.status(400).json({
                 status: "0",
-                msg: `El Club con ID ${idClub} no existe.`
+                msg: `El Club con ID ${idClub} no existe`
             });
         }
+        
+        // Validar que la Categoría exista
         const categoriaExistente = await Categoria.findByPk(idCategoria);
         if (!categoriaExistente) {
             return res.status(400).json({
                 status: "0",
-                msg: `La Categoría con ID ${idCategoria} no existe.`
+                msg: `La Categoría con ID ${idCategoria} no existe`
             });
         }
 
-        const newEquipo = await Equipo.create({ ...equipoData, idClub, idCategoria });
+        // Verificar si ya existe un equipo con el mismo nombre en el mismo club y categoría
+        const equipoExistente = await Equipo.findOne({ 
+            where: { 
+                nombre: { [Op.iLike]: nombre },
+                idClub: idClub,
+                idCategoria: idCategoria
+            } 
+        });
+        
+        if (equipoExistente) {
+            return res.status(409).json({
+                status: "0",
+                msg: `Ya existe un equipo con el nombre '${nombre}' en este club y categoría`
+            });
+        }
+
+        const equipo = await Equipo.create(req.body);
+        
         res.status(201).json({
             status: "1",
-            msg: "Equipo guardado.",
-            equipo: newEquipo
+            msg: "Equipo creado exitosamente",
+            equipo: equipo
         });
     } catch (error) {
         console.error("Error en createEquipo:", error);
-        res.status(400).json({
+        res.status(500).json({
             status: "0",
-            msg: "Error procesando operación.",
+            msg: "Error al procesar la operación",
             error: error.message
         });
     }
@@ -109,15 +153,16 @@ equipoCtrl.getEquipo = async (req, res) => {
         if (!equipo) {
             return res.status(404).json({
                 status: "0",
-                msg: "Equipo no encontrado."
+                msg: "Equipo no encontrado"
             });
         }
+        
         res.status(200).json(equipo);
     } catch (error) {
         console.error("Error en getEquipo:", error);
         res.status(500).json({
             status: "0",
-            msg: "Error procesando la operación.",
+            msg: "Error procesando la operación",
             error: error.message
         });
     }
@@ -127,7 +172,8 @@ equipoCtrl.editEquipo = async (req, res) => {
     /*
     #swagger.tags = ['Equipos']
     #swagger.summary = 'Actualizar un Equipo'
-    #swagger.description = 'Actualiza la información de un equipo existente usando su ID. Permite modificar idClub y idCategoria.'
+    #swagger.description = 'Actualiza la información de un equipo existente usando su ID. Solo accesible para administradores.'
+    #swagger.security = [{ "bearerAuth": [] }]
     #swagger.parameters['body'] = {
         in: 'body',
         description: 'Datos del equipo a actualizar.',
@@ -136,50 +182,76 @@ equipoCtrl.editEquipo = async (req, res) => {
     }
     */
     try {
-        const { idClub, idCategoria, ...equipoData } = req.body;
+        // Extracción y validación de datos
+        const { nombre, idClub, idCategoria } = req.body;
+        
+        // Verificar si existe el equipo que queremos actualizar
+        const equipoExistente = await Equipo.findByPk(req.params.id);
+        if (!equipoExistente) {
+            return res.status(404).json({
+                status: "0",
+                msg: "Equipo no encontrado para actualizar"
+            });
+        }
 
-        // Validar Club y Categoría si se proporcionan en la actualización
+        // Validar Club si se proporciona
         if (idClub) {
             const clubExistente = await Club.findByPk(idClub);
             if (!clubExistente) {
                 return res.status(400).json({
                     status: "0",
-                    msg: `El Club con ID ${idClub} no existe.`
+                    msg: `El Club con ID ${idClub} no existe`
                 });
             }
         }
+
+        // Validar Categoría si se proporciona
         if (idCategoria) {
             const categoriaExistente = await Categoria.findByPk(idCategoria);
             if (!categoriaExistente) {
                 return res.status(400).json({
                     status: "0",
-                    msg: `La Categoría con ID ${idCategoria} no existe.`
+                    msg: `La Categoría con ID ${idCategoria} no existe`
                 });
             }
         }
 
-        const [updatedRowsCount, updatedEquipos] = await Equipo.update({ ...equipoData, idClub, idCategoria }, {
-            where: { idEquipo: req.params.id },
-            returning: true
-        });
-
-        if (updatedRowsCount === 0) {
-            return res.status(404).json({
-                status: "0",
-                msg: "Equipo no encontrado para actualizar."
+        // Si se cambia el nombre, verificar unicidad en el contexto (club y categoría)
+        if (nombre && 
+            (nombre !== equipoExistente.nombre || 
+             idClub !== equipoExistente.idClub || 
+             idCategoria !== equipoExistente.idCategoria)) {
+                
+            const equipoConMismoNombre = await Equipo.findOne({
+                where: {
+                    nombre: { [Op.iLike]: nombre },
+                    idClub: idClub || equipoExistente.idClub,
+                    idCategoria: idCategoria || equipoExistente.idCategoria,
+                    idEquipo: { [Op.ne]: req.params.id }
+                }
             });
+            
+            if (equipoConMismoNombre) {
+                return res.status(409).json({
+                    status: "0",
+                    msg: `Ya existe un equipo con el nombre '${nombre}' en este club y categoría`
+                });
+            }
         }
 
+        // Actualizar equipo
+        await equipoExistente.update(req.body);
+        
         res.status(200).json({
             status: "1",
-            msg: "Equipo actualizado.",
-            equipo: updatedEquipos[0]
+            msg: "Equipo actualizado exitosamente",
+            equipo: equipoExistente
         });
     } catch (error) {
         console.error("Error en editEquipo:", error);
-        res.status(400).json({
+        res.status(500).json({
             status: "0",
-            msg: "Error procesando la operación.",
+            msg: "Error procesando la operación",
             error: error.message
         });
     }
@@ -189,29 +261,55 @@ equipoCtrl.deleteEquipo = async (req, res) => {
     /*
     #swagger.tags = ['Equipos']
     #swagger.summary = 'Eliminar un Equipo'
-    #swagger.description = 'Elimina un equipo de la base de datos usando su ID.'
+    #swagger.description = 'Elimina un equipo de la base de datos usando su ID. Solo accesible para administradores.'
+    #swagger.security = [{ "bearerAuth": [] }]
     */
     try {
-        const deletedRows = await Equipo.destroy({
-            where: { idEquipo: req.params.id }
-        });
-
-        if (deletedRows === 0) {
+        const equipo = await Equipo.findByPk(req.params.id);
+        
+        if (!equipo) {
             return res.status(404).json({
                 status: "0",
-                msg: "Equipo no encontrado para eliminar."
+                msg: "Equipo no encontrado para eliminar"
             });
         }
+        
+        // Verificar si hay referencias al equipo en otras tablas
+        // Por ejemplo, si hubiera una tabla de partidos, inscripciones, etc.
+        // Este es un ejemplo genérico, se debe adaptar según las relaciones existentes
+        /*
+        const relacionesExistentes = await OtroModelo.count({
+            where: { idEquipo: req.params.id }
+        });
+        
+        if (relacionesExistentes > 0) {
+            return res.status(400).json({
+                status: "0",
+                msg: `No se puede eliminar el equipo porque tiene ${relacionesExistentes} registros asociados`
+            });
+        }
+        */
 
+        // Eliminar el equipo
+        await equipo.destroy();
+        
         res.status(200).json({
             status: "1",
-            msg: "Equipo eliminado."
+            msg: "Equipo eliminado exitosamente"
         });
     } catch (error) {
         console.error("Error en deleteEquipo:", error);
-        res.status(400).json({
+        if (error.name === 'SequelizeForeignKeyConstraintError') {
+            return res.status(400).json({
+                status: "0",
+                msg: "No se puede eliminar el equipo porque está asociado a otros registros",
+                error: error.message
+            });
+        }
+        
+        res.status(500).json({
             status: "0",
-            msg: "Error procesando la operación.",
+            msg: "Error procesando la operación",
             error: error.message
         });
     }
@@ -225,6 +323,7 @@ equipoCtrl.getEquipoFiltro = async (req, res) => {
     #swagger.parameters['nombre'] = { in: 'query', description: 'Filtra por nombre del equipo.', type: 'string' }
     #swagger.parameters['idClub'] = { in: 'query', description: 'Filtra por ID del Club asociado.', type: 'integer' }
     #swagger.parameters['idCategoria'] = { in: 'query', description: 'Filtra por ID de la Categoría asociada.', type: 'integer' }
+    #swagger.parameters['nombreDelegado'] = { in: 'query', description: 'Filtra por nombre del delegado.', type: 'string' }
     */
     const query = req.query;
     const criteria = {};
@@ -238,21 +337,34 @@ equipoCtrl.getEquipoFiltro = async (req, res) => {
     if (query.idCategoria) {
         criteria.idCategoria = query.idCategoria;
     }
+    if (query.nombreDelegado) {
+        criteria.nombreDelegado = { [Op.iLike]: `%${query.nombreDelegado}%` };
+    }
 
     try {
         const equipos = await Equipo.findAll({
             where: criteria,
             include: [
-                { model: Club, as: 'club', attributes: ['idClub', 'nombre'] },
-                { model: Categoria, as: 'categoria', attributes: ['idCategoria', 'nombre'] }
-            ]
+                { 
+                    model: Club, 
+                    as: 'club', 
+                    attributes: ['idClub', 'nombre'] 
+                },
+                { 
+                    model: Categoria, 
+                    as: 'categoria', 
+                    attributes: ['idCategoria', 'nombre'] 
+                }
+            ],
+            order: [['nombre', 'ASC']]
         });
+        
         res.status(200).json(equipos);
     } catch (error) {
         console.error("Error en getEquipoFiltro:", error);
         res.status(500).json({
             status: "0",
-            msg: "Error procesando la operación.",
+            msg: "Error procesando la operación",
             error: error.message
         });
     }

--- a/src/routes/equipo.routes.js
+++ b/src/routes/equipo.routes.js
@@ -1,12 +1,16 @@
 const express = require("express");
 const router = express.Router();
 const equipoCtrl = require("../controllers/equipo.controller");
+const { authenticate, authorize } = require('../middleware/auth.middleware');
 
+// Rutas públicas - cualquiera puede ver los equipos
 router.get("/filter", equipoCtrl.getEquipoFiltro);
 router.get("/", equipoCtrl.getEquipos);
-router.post("/", equipoCtrl.createEquipo);
 router.get("/:id", equipoCtrl.getEquipo);
-router.put("/:id", equipoCtrl.editEquipo);
-router.delete("/:id", equipoCtrl.deleteEquipo);
+
+// Rutas protegidas - solo administradores
+router.post("/", authenticate, authorize('admin'), equipoCtrl.createEquipo);
+router.put("/:id", authenticate, authorize('admin'), equipoCtrl.editEquipo);
+router.delete("/:id", authenticate, authorize('admin'), equipoCtrl.deleteEquipo);
 
 module.exports = router;


### PR DESCRIPTION
…stión de equipos

Este commit implementa:
- Protección de rutas para que solo los administradores puedan crear, actualizar y eliminar equipos
- Acceso público para la visualización de equipos (GET)
- Validaciones exhaustivas para datos de equipos:
  - Verificación de campos obligatorios (nombre, idClub, idCategoria)
  - Validación de existencia de club y categoría referenciados
  - Prevención de duplicados por nombre+club+categoría
- Mensajes de error detallados y específicos para cada validación
- Ordenamiento alfabético por nombre
- Filtrado avanzado por múltiples criterios
- Documentación Swagger mejorada con ejemplos de autenticación

La implementación sigue el mismo patrón de seguridad ya establecido para clubes y categorías, garantizando que solo los administradores puedan modificar datos de equipos mientras se mantiene la visualización pública.